### PR TITLE
add `newFileCoverageThreshold` to config and `isNewFile` to results

### DIFF
--- a/src/__snapshots__/resultFormatter.test.ts.snap
+++ b/src/__snapshots__/resultFormatter.test.ts.snap
@@ -1,12 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resultFormatter should default to coverageThreshold for newFileCoverageThreshold 1`] = `
+"| Ok (reason)             | File        | Lines         | Branches      | Functions    | Statements    |
+| ----------------------- | ----------- | ------------- | ------------- | ------------ | ------------- |
+| 🔴<br />(Decreased >2%) | file1       | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
+| ✅                       | file2       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 1%)      | file3       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| ✅                       | (New) file4 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 1%)      | (New) file5 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+
+Total:
+
+| Lines       | Branches    | Functions   | Statements  |
+| ----------- | ----------- | ----------- | ----------- |
+| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |"
+`;
+
 exports[`resultFormatter should format files results as markdown table 1`] = `
-"| Ok | File (✨=New File) | Lines         | Branches      | Functions    | Statements    |
-| -- | ----------------- | ------------- | ------------- | ------------ | ------------- |
-| 🔴 | file1             | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
-| ✅  | file2             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
-| 🔴 | file3             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
-| ✅  | ✨ file4           | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+"| Ok (reason)             | File        | Lines         | Branches      | Functions    | Statements    |
+| ----------------------- | ----------- | ------------- | ------------- | ------------ | ------------- |
+| 🔴<br />(Decreased >2%) | file1       | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
+| ✅                       | file2       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 3%)      | file3       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| ✅                       | (New) file4 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 1%)      | (New) file5 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+
+Total:
+
+| Lines       | Branches    | Functions   | Statements  |
+| ----------- | ----------- | ----------- | ----------- |
+| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |"
+`;
+
+exports[`resultFormatter should format files results as markdown table with defaults 1`] = `
+"| Ok (reason)             | File        | Lines         | Branches      | Functions    | Statements    |
+| ----------------------- | ----------- | ------------- | ------------- | ------------ | ------------- |
+| 🔴<br />(Decreased >0%) | file1       | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
+| ✅                       | file2       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 100%)    | file3       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| ✅                       | (New) file4 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 100%)    | (New) file5 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
 
 Total:
 
@@ -17,6 +50,22 @@ Total:
 
 exports[`resultFormatter should print descriptive message if coverage did't change 1`] = `
 "Coverage values did not change👌.
+
+Total:
+
+| Lines       | Branches    | Functions   | Statements  |
+| ----------- | ----------- | ----------- | ----------- |
+| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |"
+`;
+
+exports[`resultFormatter should use defaults 1`] = `
+"| Ok (reason)             | File        | Lines         | Branches      | Functions    | Statements    |
+| ----------------------- | ----------- | ------------- | ------------- | ------------ | ------------- |
+| 🔴<br />(Decreased >0%) | file1       | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
+| ✅                       | file2       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 100%)    | file3       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| ✅                       | (New) file4 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴<br />(Below 100%)    | (New) file5 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
 
 Total:
 

--- a/src/resultFormatter.test.ts
+++ b/src/resultFormatter.test.ts
@@ -69,6 +69,23 @@ const filesResults: FilesResults = {
     },
     decreased: false,
     belowThreshold: false
+  },
+  file5: {
+    isNewFile: true,
+    deltas: {
+      lines: 10,
+      statements: 10,
+      functions: 20,
+      branches: 30
+    },
+    pcts: {
+      lines: 20,
+      statements: 5,
+      functions: 2,
+      branches: 8
+    },
+    decreased: false,
+    belowThreshold: true
   }
 };
 
@@ -92,6 +109,18 @@ const totalResults: FileResultFormat = {
 
 describe('resultFormatter', () => {
   it('should format files results as markdown table', () => {
+    expect(resultFormatter(filesResults, totalResults, 1, 2, 3)).toMatchSnapshot();
+  });
+  
+  it('should use defaults', () => {
+    expect(resultFormatter(filesResults, totalResults)).toMatchSnapshot();
+  });
+  
+  it('should default to coverageThreshold for newFileCoverageThreshold', () => {
+    expect(resultFormatter(filesResults, totalResults, 1, 2)).toMatchSnapshot();
+  });
+
+  it('should format files results as markdown table with defaults', () => {
     expect(resultFormatter(filesResults, totalResults)).toMatchSnapshot();
   });
 

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -1,11 +1,18 @@
 import markdownTable from 'markdown-table';
 import { FilesResults, FileResultFormat } from './common';
+import { defaultOptions } from './index';
 
 export const resultFormatter = (
   files: FilesResults,
-  total: FileResultFormat
+  total: FileResultFormat,
+  coverageThreshold = defaultOptions.coverageThreshold!,
+  coverageDecreaseThreshold = defaultOptions.coverageDecreaseThreshold!,
+  newFileCoverageThreshold = coverageThreshold
 ): string => {
-  const formattedFiles = formatFilesResults(files);
+  const formattedFiles = formatFilesResults(files, 
+    coverageThreshold,
+    coverageDecreaseThreshold,
+    newFileCoverageThreshold);
   const formattedTotal = formatTotal(total);
   return `${formattedFiles}${formattedTotal}`;
 };
@@ -30,12 +37,15 @@ const formatTotal = (total: FileResultFormat): string => {
   return '\n\nTotal:\n\n' + markdownTable(table);
 };
 
-const formatFilesResults = (files: FilesResults): string => {
+const formatFilesResults = (files: FilesResults,
+  coverageThreshold = defaultOptions.coverageThreshold!,
+  coverageDecreaseThreshold = defaultOptions.coverageDecreaseThreshold!,
+  newFileCoverageThreshold = coverageThreshold): string => {
   let noChange = true;
   const table: Array<(string | number)[]> = [];
   const header = [
-    'Ok',
-    'File (✨=New File)',
+    'Ok (reason)',
+    'File',
     'Lines',
     'Branches',
     'Functions',
@@ -45,9 +55,17 @@ const formatFilesResults = (files: FilesResults): string => {
 
   Object.keys(files).forEach((file) => {
     const { deltas, pcts, decreased, belowThreshold, isNewFile } = files[file];
+    const reasons = [];
+    if (belowThreshold) {
+      reasons.push(`Below ${isNewFile ? coverageThreshold : newFileCoverageThreshold}%`);
+    }
+    if (decreased) {
+      reasons.push(`Decreased >${coverageDecreaseThreshold}%`)
+    }
+
     const row = [
-      decreased || belowThreshold ? '🔴' : '✅',
-      `${isNewFile ? '✨ ' : ''}${file}`,
+      decreased || belowThreshold ? `🔴<br />(${reasons.join(" & ")})` : '✅',
+      `${isNewFile ? '(New) ' : ''}${file}`,
       `${pcts.lines}%<br>(${formatDelta(deltas.lines)})`,
       `${pcts.branches}%<br>(${formatDelta(deltas.branches)})`,
       `${pcts.functions}%<br>(${formatDelta(deltas.functions)})`,


### PR DESCRIPTION
Adding a reason to the OK column. Example below. I'm not sure I like how the text throws off alignment. but I think it'd be worse elsewhere in the table 😕 . Ideas?

> | Ok (reason)             | File        | Lines         | Branches      | Functions    | Statements    |
> | ----------------------- | ----------- | ------------- | ------------- | ------------ | ------------- |
> | 🔴<br />(Decreased >0%) | file1       | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
> | ✅                       | file2       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> | 🔴<br />(Below 100%)    | file3       | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> | ✅                       | (New) file4 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> | 🔴<br />(Below 100%)    | (New) file5 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |